### PR TITLE
add support for listing keys (active index only); test rollback

### DIFF
--- a/kvgit/bucket.py
+++ b/kvgit/bucket.py
@@ -57,8 +57,10 @@ class Bucket(object):
                 self._remote = self._repo.remotes[0]
                 if credentials:
                     self._remote.credentials = get_credentials
-                if update:
-                    self.update()
+            self._index = self._repo.index
+            self._read_tree()
+            if update and remote:
+                self.update()
         except KeyError as e:
             if e.message != path:
                 raise
@@ -70,8 +72,8 @@ class Bucket(object):
                     self._remote.credentials = get_credentials
             else:
                 self._repo = pygit2.init_repository(path, bare=True)
-        self._index = self._repo.index
-        self._read_tree()
+            self._index = self._repo.index
+            self._read_tree()
         c = self._repo.config
         self._author = author or (c['user.name'], c['user.email'])
         self._committer = committer or self._author

--- a/kvgit/bucket.py
+++ b/kvgit/bucket.py
@@ -17,7 +17,7 @@ def _check_key(key):
 class Bucket(object):
     def __init__(self, path, remote=None, author=None, committer=None,
                  timezone_offset=0, credentials=None, loader=None,
-                 update=True, dumper=None):
+                 dumper=None, update=True):
         """
         Load or initialize a repository as a bucket.
         :param path: Local path to load. If the path does not exist,

--- a/kvgit/bucket.py
+++ b/kvgit/bucket.py
@@ -58,7 +58,9 @@ class Bucket(object):
                 if credentials:
                     self._remote.credentials = get_credentials
                 self.update()
-        except KeyError:
+        except KeyError as e:
+            if e.message != path:
+                raise
             if remote:
                 self._repo = pygit2.clone_repository(remote, path, bare=True,
                                                      credentials=credentials)
@@ -142,7 +144,7 @@ class Bucket(object):
             :class:`ChangesNotCommitted`
         """
         if not self._remote:
-            raise errors.NoREmote()
+            raise errors.NoRemote()
         self._remote.fetch()
         self._repo.reset(self._repo.revparse_single(
             'refs/remotes/origin/master').oid, pygit2.GIT_RESET_SOFT)

--- a/test/test_bucket.py
+++ b/test/test_bucket.py
@@ -40,6 +40,16 @@ class BucketTestCase(unittest.TestCase):
         with self.assertRaises(kvgit.errors.RemoteMismatch):
             kvgit.bucket.Bucket(path=path, remote='foo')
 
+    def test_update_uncommitted(self):
+        path = '_test_temp/cloned.git'
+        bucket = kvgit.bucket.Bucket(path=path, remote=self.test_repo_path)
+        bucket['foo'] = 'bar'
+        bucket.commit()
+        bucket.update()
+        bucket['foo'] = 'biz'
+        with self.assertRaises(kvgit.errors.ChangesNotCommitted):
+            bucket.update()
+
     def test_commit_after_update(self):
         path = '_test_temp/cloned.git'
         bucket = kvgit.bucket.Bucket(path=path, remote=self.test_repo_path)

--- a/test/test_bucket.py
+++ b/test/test_bucket.py
@@ -43,16 +43,19 @@ class BucketTestCase(unittest.TestCase):
     def test_commit_after_update(self):
         path = '_test_temp/cloned.git'
         bucket = kvgit.bucket.Bucket(path=path, remote=self.test_repo_path)
-        bucket.commit('foo', 'bar')
+        bucket['foo'] = 'bar'
+        bucket.commit()
         bucket.update()
-        bucket.commit('foo', 'foo')
+        bucket['foo'] = 'foo'
+        bucket.commit()
 
     def test_commit_and_update(self):
         b1 = kvgit.bucket.Bucket(path='_test_temp/clone1.git',
                                  remote=self.test_repo_path)
         b2 = kvgit.bucket.Bucket(path='_test_temp/clone2.git',
                                  remote=self.test_repo_path)
-        b1.commit('foo', 'bar')
+        b1['foo'] = 'bar'
+        b1.commit()
         self.assertEqual(b2.get('foo'), None)
         b2.update()
         self.assertEqual(b2.get('foo'), 'bar')
@@ -62,9 +65,11 @@ class BucketTestCase(unittest.TestCase):
                                  remote=self.test_repo_path)
         b2 = kvgit.bucket.Bucket(path='_test_temp/clone2.git',
                                  remote=self.test_repo_path)
-        b1.commit('foo', 'bar')
+        b1['foo'] = 'bar'
+        b1.commit()
         with self.assertRaises(kvgit.errors.CommitError):
-            b2.commit('foo', 'foo')
+            b2['foo'] = 'foo'
+            b2.commit()
         self.assertEqual(b2['foo'], 'bar')
 
     def test_check_key(self):
@@ -76,6 +81,20 @@ class BucketTestCase(unittest.TestCase):
         self.bucket['foo/bar'] = 'bar'
         self.assertEqual(self.bucket['foo/bar'], 'bar')
 
+    def test_list(self):
+        items = ['foo', 'bar', 'biz/baz']
+        for i in items:
+            self.bucket[i] = ''
+        self.assertEqual(sorted(self.bucket.list()), sorted(items))
+        self.assertEqual(self.bucket.list('biz'), ['baz'])
+
+    def test_delete(self):
+        self.bucket['was/here'] = 'something'
+        self.assertEqual(self.bucket['was/here'], 'something')
+        del self.bucket['was/here']
+        with self.assertRaises(KeyError):
+            self.bucket['was/here']
+
     def test_get_absent(self):
         self.assertEqual(self.bucket.get('not/here'), None)
         with self.assertRaises(KeyError):
@@ -84,12 +103,30 @@ class BucketTestCase(unittest.TestCase):
     def test_commit(self):
         self.bucket['foo/bar'] = 'bar'
         self.bucket.commit()
-        self.assertEqual(self.bucket._staged, {})
         self.assertEqual(self.bucket.get('foo/bar'), 'bar')
         self.bucket['biz/baz'] = 'bar'
         self.bucket.commit()
         self.assertEqual(self.bucket.get('biz/baz'), 'bar')
         self.assertEqual(self.bucket.get('foo/bar'), 'bar')
+
+    def test_rollback(self):
+        self.bucket['foo/bar'] = 'bar'
+        self.bucket.commit()
+        self.assertEqual(self.bucket.get('foo/bar'), 'bar')
+        self.bucket['foo/bar'] = 'baz'
+        self.assertEqual(self.bucket.get('foo/bar'), 'baz')
+        self.bucket.rollback()
+        self.assertEqual(self.bucket.get('foo/bar'), 'bar')
+
+    def test_rollback_key(self):
+        self.bucket['foo/bar'] = 'bar'
+        self.bucket['foo/baz'] = 'bar'
+        self.bucket.commit()
+        self.bucket['foo/bar'] = 'baz'
+        self.bucket['foo/baz'] = 'baz'
+        self.bucket.rollback('foo/baz')
+        self.bucket['foo/bar'] = 'baz'
+        self.bucket['foo/baz'] = 'bar'
 
     def test_get_not_staged(self):
         self.bucket['foo'] = 'foo'
@@ -98,10 +135,12 @@ class BucketTestCase(unittest.TestCase):
         self.assertEqual(self.bucket.get('foo', staged=False), 'foo')
 
     def test_multiple_commits(self):
-        self.bucket.commit('foo', 'bar')
+        self.bucket['foo'] = 'bar'
+        self.bucket.commit()
         bucket = kvgit.bucket.Bucket(path=self.test_repo_path,
                                      author=('test', 'test@test'))
-        bucket.commit('bar', 'foo')
+        bucket['bar'] = 'foo'
+        bucket.commit()
         self.assertEqual(bucket['foo'], 'bar')
 
     def test_json_load_dump(self):


### PR DESCRIPTION
This commit adds support for Bucket.list() and Bucket.list(prefix) functions.

Note: I removed the Bucket.commit(key, value) convenience function, as the code changes in this commit would have made keeping it much more complex.
